### PR TITLE
Renommage des canaux Slack

### DIFF
--- a/slack-channels.csv
+++ b/slack-channels.csv
@@ -27,7 +27,7 @@ startup-etu_ent-info,false,"Discussions pouvant intéresser le reste de l’incu
 incubateur-live,false,"Livestreaming / blogging / tweeting d'événements (hackathons, séminaires…).",14
 **incubateur-strategie**,false,"Stratégie, vision partagée, futur de l’incubateur, amélioration continue, idées, bonheurs et douleurs, émanées aux rétrospectives et séminaires =&gt;  LIVE XXX",32
 **incubateur-annonces**,false,"https://github.com/sgmap/beta.gouv.fr/wiki/",59
-**general**,false,"Tu n'as trouvé aucun endroit où poster ? Allez, mets-le ici. On te redigera au besoin ;)",59
+**general**,false,"Tu n'as trouvé aucun endroit où poster ? Allez, mets-le ici. On te redirigera au besoin ;)",59
 api-geo,false,"Travaux autour de la GéoAPI et de feu API Carto",13
 incubateur-infra,false,"https://docs.google.com/spreadsheets/XXX",21
 startup-inspire,false,":pineapple:",7

--- a/slack-channels.csv
+++ b/slack-channels.csv
@@ -20,7 +20,7 @@ choix-domaine,true,"",0
 choix-nom-de-domain,true,"",0
 random-commies,false,"Sans MS",9
 data,true,"La donnée en général",0
-experts-ux,false,"Aime le problème, pas la solution ! UX, UI, custdev, lean startup, jobs-to-be-done, service design, ethno, etc.",34
+guilde-ux,false,"Aime le problème, pas la solution ! UX, UI, custdev, lean startup, jobs-to-be-done, service design, ethno, etc.",34
 startup-etu_ent,false,"Discussion internes de la start-up étudiant entrepreneur (tout ce qui n’intéresse que nous et pas l’incubateur) XXX",3
 startup-embauche,false,"https://embauche.beta.gouv.fr",9
 startup-etu_ent-info,false,"Discussions pouvant intéresser le reste de l’incubateur, meilleur endroit pour porter un sujet à l’attention de l’équipe.\r\nhttps://github.com/sgmap/etudiant-entrepreneur\r\n",6
@@ -30,7 +30,7 @@ meta-strategie,false,"Stratégie, vision partagée, futur de l’incubateur, am�
 api-geo,false,"Travaux autour de la GéoAPI et de feu API Carto",13
 meta-infra,false,"https://docs.google.com/spreadsheets/XXX",21
 startup-inspire,false,":pineapple:",7
-experts-intrapreneurs,false,"",9
+guilde-intrapreneurs,false,"",9
 startup-ludwig,false,"",3
 marketplace,true,"",0
 startup-mdph,false,"https://mdph.beta.gouv.fr",6
@@ -40,25 +40,25 @@ startup-mpal,false,"",9
 mutinerie,true,"",0
 meta-nouveaux,false,"https://github.com/sgmap/beta.gouv.fr/wiki/Bienvenue",33
 startup-openacademie,false,"",7
-experts-opendata,false,"Actualités et discussions en rapport avec l’ouverture des données. L’équipe #datagouv est sur chat.code.gouv2.fr.",14
+guilde-opendata,false,"Actualités et discussions en rapport avec l’ouverture des données. L’équipe #datagouv est sur chat.code.gouv2.fr.",14
 openfisca,false,"",3
 startup-pix-info,false,"",12
 startup-pix-ci,false,"",3
 startup-pix,false,"",4
 startup-plante_etmoi,false,"Tâches en cours : https://github.com/sgmap/plante-et-moi/projects/1",7
-groupe-pole_emploi,false,"",10
+tribu-pole_emploi,false,"",10
 random-politique,false,"",5
 random,false,"",57
 meta-recrutement,false,"Qui pourrait nous rejoindre ?",18
 repas-de-noel-2016,true,"",7
 meta-reseaux_sociaux,false,"https://github.com/sgmap/beta.gouv.fr/wiki/Réseaux-sociaux",15
 startup-retraites,false,"",5
-experts-security,false,"",8
+guilde-security,false,"",8
 service-public-donnee,true,"",12
 taxi-internal,true,"",0
 startup-taxis-info,false,"https://le.taxi",11
 startup-taxis,false,"",2
-experts-dev,false,"",30
+guilde-dev,false,"",30
 tes,false,"",14
 startup-tps,false,"",32
 true-pix,true,"",0

--- a/slack-channels.csv
+++ b/slack-channels.csv
@@ -1,68 +1,68 @@
 Nom,Archivé,Topic,Membres
-administration,false,"https://github.com/sgmap/beta.gouv.fr/wiki/Administration",22
+meta-admin,false,"https://github.com/sgmap/beta.gouv.fr/wiki/Administration",22
+startup-api_gouv,false,"https://api.gouv.fr",23
+api-entreprise,false,"",8
 api-medicaments,true,"",0
-api_gouv,false,"api.gouv.fr",23
-apientreprise,false,"",8
-apipart-internal,false,"",0
-apiparticulier,false,"",11
-au-bistro,false,"",18
+api-particulier-team,false,"",0
+api-particulier,false,"",11
 babies,true,"",0
-beta_gouv,false,"beta.gouv.fr",22
+meta-bistro,false,"",18
+startup-beta_gouv,false,"beta.gouv.fr",22
 bof-octo,true,"",0
-bourse,false,"",4
-boussole,false,"https://beta.gouv.fr/startup/boussole",13
+startup-bourse,false,"",4
+startup-boussole,false,"https://beta.gouv.fr/startup/boussole",13
 bureaux-mirabeau,false,"39 quai André Citroën, 75015, Salle XXX, XXX , Horaires de sieste/méditation: 13h - 14h",22
 bureaux-mutinerie,false,"porte d'entrée : XXX wifi : XXX -&gt; XXX",16
 bureaux-sully,false,"86 allée de Bercy, 75012 Paris. Salle XXX. WiFi : XXX",15
-cellulepsychologique,false,"",5
-chez-wam,false,"https://github.com/krichtof/chez-wam/wiki",11
+random-rachat,false,"",5
+startup-chez_wam,false,"https://github.com/krichtof/chez-wam/wiki",11
 choix-domaine,true,"",0
 choix-nom-de-domain,true,"",0
-commies,false,"Sans MS",9
+random-commies,false,"Sans MS",9
 data,true,"La donnée en général",0
-design-de-service,false,"Aime le problème, pas la solution ! UX, UI, custdev, lean startup, jobs-to-be-done, service design, ethno, etc.",34
-ee-internal,false,"Discussion internes de la start-up étudiant entrepreneur (tout ce qui n’intéresse que nous et pas l’incubateur) XXX",3
-embauche,false,"https://embauche.beta.gouv.fr",9
-etudiant-entrepreneur,false,"Discussions pouvant intéresser le reste de l’incubateur, meilleur endroit pour porter un sujet à l’attention de l’équipe.\r\nhttps://github.com/sgmap/etudiant-entrepreneur\r\n",6
-events,false,"",14
-fil-rouge,false,"Stratégie, vision partagée, futur de l’incubateur, amélioration continue, idées, bonheurs et douleurs, émanées aux rétrospectives et séminaires =&gt;  LIVE XXX",32
-general,false,"https://github.com/sgmap/beta.gouv.fr/wiki/",59
-geoapi,false,"Travaux autour de la GéoAPI et de feu API Carto",13
-infra,false,"https://docs.google.com/spreadsheets/XXX",21
-inspire,false,":pineapple:",7
-intrapreneur-en-start,false,"",9
-ludwig,false,"",3
+experts-ux,false,"Aime le problème, pas la solution ! UX, UI, custdev, lean startup, jobs-to-be-done, service design, ethno, etc.",34
+startup-etu_ent-team,false,"Discussion internes de la start-up étudiant entrepreneur (tout ce qui n’intéresse que nous et pas l’incubateur) XXX",3
+startup-embauche,false,"https://embauche.beta.gouv.fr",9
+startup-etu_ent,false,"Discussions pouvant intéresser le reste de l’incubateur, meilleur endroit pour porter un sujet à l’attention de l’équipe.\r\nhttps://github.com/sgmap/etudiant-entrepreneur\r\n",6
+meta-evenements_live,false,"Livestreaming / blogging / tweeting d'événements (hackathons, séminaires…).",14
+meta-strategie,false,"Stratégie, vision partagée, futur de l’incubateur, amélioration continue, idées, bonheurs et douleurs, émanées aux rétrospectives et séminaires =&gt;  LIVE XXX",32
+**meta-annonces**,false,"https://github.com/sgmap/beta.gouv.fr/wiki/",59
+api-geo,false,"Travaux autour de la GéoAPI et de feu API Carto",13
+meta-infra,false,"https://docs.google.com/spreadsheets/XXX",21
+startup-inspire,false,":pineapple:",7
+experts-intrapreneurs,false,"",9
+startup-ludwig,false,"",3
 marketplace,true,"",0
-mdph,false,"https://mdph.beta.gouv.fr",6
-mes-aides,false,"https://mes-aides.gouv.fr",11
-mes-aides-internals,false,"",4
-mpal,false,"",9
+startup-mdph,false,"https://mdph.beta.gouv.fr",6
+startup-mes_aides,false,"https://mes-aides.gouv.fr",11
+startup-mes_aid-team,false,"",4
+startup-mpal,false,"",9
 mutinerie,true,"",0
-nouveaux,false,"https://github.com/sgmap/beta.gouv.fr/wiki/Bienvenue",33
-openacademie,false,"",7
-opendata,false,"Actualités et discussions en rapport avec l’ouverture des données. L’équipe #datagouv est sur chat.code.gouv2.fr.",14
+meta-nouveaux,false,"https://github.com/sgmap/beta.gouv.fr/wiki/Bienvenue",33
+startup-openacademie,false,"",7
+experts-opendata,false,"Actualités et discussions en rapport avec l’ouverture des données. L’équipe #datagouv est sur chat.code.gouv2.fr.",14
 openfisca,false,"",3
-pix,false,"",12
-pix-ci,false,"",3
-pix-internals,false,"",4
-plante-et-moi,false,"Tâches en cours : https://github.com/sgmap/plante-et-moi/projects/1",7
-pole-emploi,false,"",10
-politique,false,"",5
+startup-pix,false,"",12
+startup-pix-ci,false,"",3
+startup-pix-team,false,"",4
+startup-plante_etmoi,false,"Tâches en cours : https://github.com/sgmap/plante-et-moi/projects/1",7
+groupe-pole_emploi,false,"",10
+random-politique,false,"",5
 random,false,"",57
-recrutement,false,"Qui pourrait nous rejoindre ?",18
-repas-de-noel-2016,false,"",7
-reseaux-sociaux,false,"https://github.com/sgmap/beta.gouv.fr/wiki/Réseaux-sociaux",15
-retraites,false,"",5
-security,false,"",8
-service-public-donnee,false,"",12
+meta-recrutement,false,"Qui pourrait nous rejoindre ?",18
+repas-de-noel-2016,true,"",7
+meta-reseaux_sociaux,false,"https://github.com/sgmap/beta.gouv.fr/wiki/Réseaux-sociaux",15
+startup-retraites,false,"",5
+experts-security,false,"",8
+service-public-donnee,true,"",12
 taxi-internal,true,"",0
-taxis,false,"https://le.taxi",11
-taxis-internal,false,"",2
-tech,false,"",30
+startup-taxis,false,"https://le.taxi",11
+startup-taxis-team,false,"",2
+experts-dev,false,"",30
 tes,false,"",14
-tps,false,"",32
+startup-tps,false,"",32
 true-pix,true,"",0
 urbaclic,false,"",11
-ux,false,"",1
-vacances,false,"On avait un peu bu au pot de Thibaut et on s'est dit que ça serait fun, ok @maukoquiroga ??",29
-verif-site,false,"Channel pour discuter du produit https://verif.site",9
+ux,true,"",1
+random-vacances,false,"On avait un peu bu au pot de Thibaut et on s'est dit que ça serait fun, ok @maukoquiroga ??",29
+startup-verif_site,false,"Channel pour discuter du produit https://verif.site",9

--- a/slack-channels.csv
+++ b/slack-channels.csv
@@ -66,3 +66,4 @@ startup-urbaclic,false,"",11
 ux,true,"",1
 bruit-vacances,false,"On avait un peu bu au pot de Thibaut et on s'est dit que ça serait fun, ok @maukoquiroga ??",29
 startup-verif_site,false,"Channel pour discuter du produit https://verif.site",9
+incubateur-veille,true,"Revue de presse",_

--- a/slack-channels.csv
+++ b/slack-channels.csv
@@ -3,8 +3,8 @@ meta-admin,false,"https://github.com/sgmap/beta.gouv.fr/wiki/Administration",22
 startup-api_gouv,false,"https://api.gouv.fr",23
 api-entreprise,false,"",8
 api-medicaments,true,"",0
-api-particulier,false,"",0
-api-particulier-info,false,"",11
+apiparticulier,true,"",0
+api-particulier,false,"",11
 babies,true,"",0
 meta-bistro,false,"",18
 startup-beta_gouv,false,"beta.gouv.fr",22

--- a/slack-channels.csv
+++ b/slack-channels.csv
@@ -14,11 +14,11 @@ startup-boussole,false,"https://beta.gouv.fr/startup/boussole",13
 bureaux-mirabeau,false,"39 quai André Citroën, 75015, Salle XXX, XXX , Horaires de sieste/méditation: 13h - 14h",22
 bureaux-mutinerie,false,"porte d'entrée : XXX wifi : XXX -&gt; XXX",16
 bureaux-sully,false,"86 allée de Bercy, 75012 Paris. Salle XXX. WiFi : XXX",15
-random-rachat,false,"",5
+bruit-rachat,false,"",5
 startup-chez_wam,false,"https://github.com/krichtof/chez-wam/wiki",11
 choix-domaine,true,"",0
 choix-nom-de-domain,true,"",0
-random-commies,false,"Sans MS",9
+bruit-commies,false,"Sans MS",9
 data,true,"La donnée en général",0
 guilde-ux,false,"Aime le problème, pas la solution ! UX, UI, custdev, lean startup, jobs-to-be-done, service design, ethno, etc.",34
 startup-etu_ent,false,"Discussion internes de la start-up étudiant entrepreneur (tout ce qui n’intéresse que nous et pas l’incubateur) XXX",3
@@ -47,7 +47,7 @@ startup-pix-ci,false,"",3
 startup-pix,false,"",4
 startup-plante_etmoi,false,"Tâches en cours : https://github.com/sgmap/plante-et-moi/projects/1",7
 tribu-pole_emploi,false,"",10
-random-politique,false,"",5
+bruit-politique,false,"",5
 random,false,"",57
 meta-recrutement,false,"Qui pourrait nous rejoindre ?",18
 repas-de-noel-2016,true,"",7
@@ -64,5 +64,5 @@ startup-tps,false,"",32
 true-pix,true,"",0
 startup-urbaclic,false,"",11
 ux,true,"",1
-random-vacances,false,"On avait un peu bu au pot de Thibaut et on s'est dit que ça serait fun, ok @maukoquiroga ??",29
+bruit-vacances,false,"On avait un peu bu au pot de Thibaut et on s'est dit que ça serait fun, ok @maukoquiroga ??",29
 startup-verif_site,false,"Channel pour discuter du produit https://verif.site",9

--- a/slack-channels.csv
+++ b/slack-channels.csv
@@ -62,7 +62,7 @@ guilde-dev,false,"",30
 tes,false,"",14
 startup-tps,false,"",32
 true-pix,true,"",0
-urbaclic,false,"",11
+startup-urbaclic,false,"",11
 ux,true,"",1
 random-vacances,false,"On avait un peu bu au pot de Thibaut et on s'est dit que ça serait fun, ok @maukoquiroga ??",29
 startup-verif_site,false,"Channel pour discuter du produit https://verif.site",9

--- a/slack-channels.csv
+++ b/slack-channels.csv
@@ -60,7 +60,7 @@ taxi-internal,true,"",0
 startup-taxis-info,false,"https://le.taxi",11
 startup-taxis,false,"",2
 domaine-dev,false,"",30
-tes,false,"",14
+tes,true,"",14
 startup-tps,false,"",32
 true-pix,true,"",0
 startup-urbaclic,false,"",11

--- a/slack-channels.csv
+++ b/slack-channels.csv
@@ -6,7 +6,7 @@ api-medicaments,true,"",0
 apiparticulier,true,"",0
 api-particulier,false,"",11
 babies,true,"",0
-incubateur-bistro,false,"",18
+**incubateur-sorties**,false,"",18
 startup-beta_gouv,false,"beta.gouv.fr",22
 bof-octo,true,"",0
 startup-bourse,false,"",4
@@ -25,9 +25,9 @@ startup-etu_ent,false,"Discussion internes de la start-up étudiant entrepreneur
 startup-embauche,false,"https://embauche.beta.gouv.fr",9
 startup-etu_ent-info,false,"Discussions pouvant intéresser le reste de l’incubateur, meilleur endroit pour porter un sujet à l’attention de l’équipe.\r\nhttps://github.com/sgmap/etudiant-entrepreneur\r\n",6
 incubateur-live,false,"Livestreaming / blogging / tweeting d'événements (hackathons, séminaires…).",14
-incubateur-strategie,false,"Stratégie, vision partagée, futur de l’incubateur, amélioration continue, idées, bonheurs et douleurs, émanées aux rétrospectives et séminaires =&gt;  LIVE XXX",32
+**incubateur-strategie**,false,"Stratégie, vision partagée, futur de l’incubateur, amélioration continue, idées, bonheurs et douleurs, émanées aux rétrospectives et séminaires =&gt;  LIVE XXX",32
 **incubateur-annonces**,false,"https://github.com/sgmap/beta.gouv.fr/wiki/",59
-general,false,"Tu n'as trouvé aucun endroit où poster ? Allez, mets-le ici. On te redigera au besoin ;)",59
+**general**,false,"Tu n'as trouvé aucun endroit où poster ? Allez, mets-le ici. On te redigera au besoin ;)",59
 api-geo,false,"Travaux autour de la GéoAPI et de feu API Carto",13
 incubateur-infra,false,"https://docs.google.com/spreadsheets/XXX",21
 startup-inspire,false,":pineapple:",7
@@ -39,7 +39,7 @@ startup-mes_aid-info,false,"https://mes-aides.gouv.fr",11
 startup-mes_aid,false,"",4
 startup-mpal,false,"",9
 mutinerie,true,"",0
-incubateur-nouveaux,false,"https://github.com/sgmap/beta.gouv.fr/wiki/Bienvenue",33
+**incubateur-nouveaux**,false,"https://github.com/sgmap/beta.gouv.fr/wiki/Bienvenue",33
 startup-openacademie,false,"",7
 domaine-opendata,false,"Actualités et discussions en rapport avec l’ouverture des données. L’équipe #datagouv est sur chat.code.gouv2.fr.",14
 openfisca,false,"",3
@@ -49,7 +49,7 @@ startup-pix,false,"",4
 startup-plante_etmoi,false,"Tâches en cours : https://github.com/sgmap/plante-et-moi/projects/1",7
 pole_emploi,true,"",10
 bruit-politique,false,"",5
-random,false,"",57
+**random**,false,"",57
 incubateur-recrutemt,false,"Qui pourrait nous rejoindre ?",18
 repas-de-noel-2016,true,"",7
 incubateur-reseaux,false,"https://github.com/sgmap/beta.gouv.fr/wiki/Réseaux-sociaux",15
@@ -67,4 +67,4 @@ startup-urbaclic,false,"",11
 ux,true,"",1
 bruit-vacances,false,"On avait un peu bu au pot de Thibaut et on s'est dit que ça serait fun, ok @maukoquiroga ??",29
 startup-verif_site,false,"Channel pour discuter du produit https://verif.site",9
-incubateur-veille,true,"Revue de presse",_
+**incubateur-veille**,true,"Revue de presse",_

--- a/slack-channels.csv
+++ b/slack-channels.csv
@@ -20,7 +20,7 @@ choix-domaine,true,"",0
 choix-nom-de-domain,true,"",0
 bruit-commies,false,"Sans MS",9
 data,true,"La donnée en général",0
-guilde-ux,false,"Aime le problème, pas la solution ! UX, UI, custdev, lean startup, jobs-to-be-done, service design, ethno, etc.",34
+domaine-ux,false,"Aime le problème, pas la solution ! UX, UI, custdev, lean startup, jobs-to-be-done, service design, ethno, etc.",34
 startup-etu_ent,false,"Discussion internes de la start-up étudiant entrepreneur (tout ce qui n’intéresse que nous et pas l’incubateur) XXX",3
 startup-embauche,false,"https://embauche.beta.gouv.fr",9
 startup-etu_ent-info,false,"Discussions pouvant intéresser le reste de l’incubateur, meilleur endroit pour porter un sujet à l’attention de l’équipe.\r\nhttps://github.com/sgmap/etudiant-entrepreneur\r\n",6
@@ -30,7 +30,7 @@ incubateur-strategie,false,"Stratégie, vision partagée, futur de l’incubateu
 api-geo,false,"Travaux autour de la GéoAPI et de feu API Carto",13
 incubateur-infra,false,"https://docs.google.com/spreadsheets/XXX",21
 startup-inspire,false,":pineapple:",7
-guilde-intrapreneurs,false,"",9
+domaine-intrapreneur,false,"",9
 startup-ludwig,false,"",3
 marketplace,true,"",0
 startup-mdph,false,"https://mdph.beta.gouv.fr",6
@@ -40,7 +40,7 @@ startup-mpal,false,"",9
 mutinerie,true,"",0
 incubateur-nouveaux,false,"https://github.com/sgmap/beta.gouv.fr/wiki/Bienvenue",33
 startup-openacademie,false,"",7
-guilde-opendata,false,"Actualités et discussions en rapport avec l’ouverture des données. L’équipe #datagouv est sur chat.code.gouv2.fr.",14
+domaine-opendata,false,"Actualités et discussions en rapport avec l’ouverture des données. L’équipe #datagouv est sur chat.code.gouv2.fr.",14
 openfisca,false,"",3
 startup-pix-info,false,"",12
 startup-pix-ci,false,"",3
@@ -53,12 +53,12 @@ incubateur-recrutemt,false,"Qui pourrait nous rejoindre ?",18
 repas-de-noel-2016,true,"",7
 incubateur-reseaux,false,"https://github.com/sgmap/beta.gouv.fr/wiki/Réseaux-sociaux",15
 startup-retraites,false,"",5
-guilde-security,false,"",8
+domaine-secu,false,"",8
 service-public-donnee,true,"",12
 taxi-internal,true,"",0
 startup-taxis-info,false,"https://le.taxi",11
 startup-taxis,false,"",2
-guilde-dev,false,"",30
+domaine-dev,false,"",30
 tes,false,"",14
 startup-tps,false,"",32
 true-pix,true,"",0

--- a/slack-channels.csv
+++ b/slack-channels.csv
@@ -21,9 +21,9 @@ choix-nom-de-domain,true,"",0
 bruit-commies,false,"Sans MS",9
 data,true,"La donnée en général",0
 domaine-ux,false,"Aime le problème, pas la solution ! UX, UI, custdev, lean startup, jobs-to-be-done, service design, ethno, etc.",34
-startup-etu_ent,false,"Discussion internes de la start-up étudiant entrepreneur (tout ce qui n’intéresse que nous et pas l’incubateur) XXX",3
+startup-EE,false,"Discussion internes de la start-up étudiant entrepreneur (tout ce qui n’intéresse que nous et pas l’incubateur) XXX",3
 startup-embauche,false,"https://embauche.beta.gouv.fr",9
-startup-etu_ent-info,false,"Discussions pouvant intéresser le reste de l’incubateur, meilleur endroit pour porter un sujet à l’attention de l’équipe.\r\nhttps://github.com/sgmap/etudiant-entrepreneur\r\n",6
+startup-EE-info,false,"Discussions pouvant intéresser le reste de l’incubateur, meilleur endroit pour porter un sujet à l’attention de l’équipe.\r\nhttps://github.com/sgmap/etudiant-entrepreneur\r\n",6
 incubateur-live,false,"Livestreaming / blogging / tweeting d'événements (hackathons, séminaires…).",14
 **incubateur-strategie**,false,"Stratégie, vision partagée, futur de l’incubateur, amélioration continue, idées, bonheurs et douleurs, émanées aux rétrospectives et séminaires =&gt;  LIVE XXX",32
 **incubateur-annonces**,false,"https://github.com/sgmap/beta.gouv.fr/wiki/",59

--- a/slack-channels.csv
+++ b/slack-channels.csv
@@ -1,12 +1,12 @@
 Nom,Archivé,Topic,Membres
-meta-admin,false,"https://github.com/sgmap/beta.gouv.fr/wiki/Administration",22
+incubateur-admin,false,"https://github.com/sgmap/beta.gouv.fr/wiki/Administration",22
 startup-api_gouv,false,"https://api.gouv.fr",23
 api-entreprise,false,"",8
 api-medicaments,true,"",0
 apiparticulier,true,"",0
 api-particulier,false,"",11
 babies,true,"",0
-meta-bistro,false,"",18
+incubateur-bistro,false,"",18
 startup-beta_gouv,false,"beta.gouv.fr",22
 bof-octo,true,"",0
 startup-bourse,false,"",4
@@ -24,11 +24,11 @@ guilde-ux,false,"Aime le problème, pas la solution ! UX, UI, custdev, lean star
 startup-etu_ent,false,"Discussion internes de la start-up étudiant entrepreneur (tout ce qui n’intéresse que nous et pas l’incubateur) XXX",3
 startup-embauche,false,"https://embauche.beta.gouv.fr",9
 startup-etu_ent-info,false,"Discussions pouvant intéresser le reste de l’incubateur, meilleur endroit pour porter un sujet à l’attention de l’équipe.\r\nhttps://github.com/sgmap/etudiant-entrepreneur\r\n",6
-meta-evenements_live,false,"Livestreaming / blogging / tweeting d'événements (hackathons, séminaires…).",14
-meta-strategie,false,"Stratégie, vision partagée, futur de l’incubateur, amélioration continue, idées, bonheurs et douleurs, émanées aux rétrospectives et séminaires =&gt;  LIVE XXX",32
-**meta-annonces**,false,"https://github.com/sgmap/beta.gouv.fr/wiki/",59
+incubateur-live,false,"Livestreaming / blogging / tweeting d'événements (hackathons, séminaires…).",14
+incubateur-strategie,false,"Stratégie, vision partagée, futur de l’incubateur, amélioration continue, idées, bonheurs et douleurs, émanées aux rétrospectives et séminaires =&gt;  LIVE XXX",32
+**incubateur-annonces**,false,"https://github.com/sgmap/beta.gouv.fr/wiki/",59
 api-geo,false,"Travaux autour de la GéoAPI et de feu API Carto",13
-meta-infra,false,"https://docs.google.com/spreadsheets/XXX",21
+incubateur-infra,false,"https://docs.google.com/spreadsheets/XXX",21
 startup-inspire,false,":pineapple:",7
 guilde-intrapreneurs,false,"",9
 startup-ludwig,false,"",3
@@ -38,7 +38,7 @@ startup-mes_aid-info,false,"https://mes-aides.gouv.fr",11
 startup-mes_aid,false,"",4
 startup-mpal,false,"",9
 mutinerie,true,"",0
-meta-nouveaux,false,"https://github.com/sgmap/beta.gouv.fr/wiki/Bienvenue",33
+incubateur-nouveaux,false,"https://github.com/sgmap/beta.gouv.fr/wiki/Bienvenue",33
 startup-openacademie,false,"",7
 guilde-opendata,false,"Actualités et discussions en rapport avec l’ouverture des données. L’équipe #datagouv est sur chat.code.gouv2.fr.",14
 openfisca,false,"",3
@@ -49,9 +49,9 @@ startup-plante_etmoi,false,"Tâches en cours : https://github.com/sgmap/plante-e
 pole_emploi,true,"",10
 bruit-politique,false,"",5
 random,false,"",57
-meta-recrutement,false,"Qui pourrait nous rejoindre ?",18
+incubateur-recrutemt,false,"Qui pourrait nous rejoindre ?",18
 repas-de-noel-2016,true,"",7
-meta-reseaux_sociaux,false,"https://github.com/sgmap/beta.gouv.fr/wiki/Réseaux-sociaux",15
+incubateur-reseaux,false,"https://github.com/sgmap/beta.gouv.fr/wiki/Réseaux-sociaux",15
 startup-retraites,false,"",5
 guilde-security,false,"",8
 service-public-donnee,true,"",12

--- a/slack-channels.csv
+++ b/slack-channels.csv
@@ -27,6 +27,7 @@ startup-etu_ent-info,false,"Discussions pouvant intéresser le reste de l’incu
 incubateur-live,false,"Livestreaming / blogging / tweeting d'événements (hackathons, séminaires…).",14
 incubateur-strategie,false,"Stratégie, vision partagée, futur de l’incubateur, amélioration continue, idées, bonheurs et douleurs, émanées aux rétrospectives et séminaires =&gt;  LIVE XXX",32
 **incubateur-annonces**,false,"https://github.com/sgmap/beta.gouv.fr/wiki/",59
+general,false,"Tu n'as trouvé aucun endroit où poster ? Allez, mets-le ici. On te redigera au besoin ;)",59
 api-geo,false,"Travaux autour de la GéoAPI et de feu API Carto",13
 incubateur-infra,false,"https://docs.google.com/spreadsheets/XXX",21
 startup-inspire,false,":pineapple:",7

--- a/slack-channels.csv
+++ b/slack-channels.csv
@@ -3,8 +3,8 @@ meta-admin,false,"https://github.com/sgmap/beta.gouv.fr/wiki/Administration",22
 startup-api_gouv,false,"https://api.gouv.fr",23
 api-entreprise,false,"",8
 api-medicaments,true,"",0
-api-particulier-team,false,"",0
-api-particulier,false,"",11
+api-particulier,false,"",0
+api-particulier-info,false,"",11
 babies,true,"",0
 meta-bistro,false,"",18
 startup-beta_gouv,false,"beta.gouv.fr",22
@@ -21,9 +21,9 @@ choix-nom-de-domain,true,"",0
 random-commies,false,"Sans MS",9
 data,true,"La donnée en général",0
 experts-ux,false,"Aime le problème, pas la solution ! UX, UI, custdev, lean startup, jobs-to-be-done, service design, ethno, etc.",34
-startup-etu_ent-team,false,"Discussion internes de la start-up étudiant entrepreneur (tout ce qui n’intéresse que nous et pas l’incubateur) XXX",3
+startup-etu_ent,false,"Discussion internes de la start-up étudiant entrepreneur (tout ce qui n’intéresse que nous et pas l’incubateur) XXX",3
 startup-embauche,false,"https://embauche.beta.gouv.fr",9
-startup-etu_ent,false,"Discussions pouvant intéresser le reste de l’incubateur, meilleur endroit pour porter un sujet à l’attention de l’équipe.\r\nhttps://github.com/sgmap/etudiant-entrepreneur\r\n",6
+startup-etu_ent-info,false,"Discussions pouvant intéresser le reste de l’incubateur, meilleur endroit pour porter un sujet à l’attention de l’équipe.\r\nhttps://github.com/sgmap/etudiant-entrepreneur\r\n",6
 meta-evenements_live,false,"Livestreaming / blogging / tweeting d'événements (hackathons, séminaires…).",14
 meta-strategie,false,"Stratégie, vision partagée, futur de l’incubateur, amélioration continue, idées, bonheurs et douleurs, émanées aux rétrospectives et séminaires =&gt;  LIVE XXX",32
 **meta-annonces**,false,"https://github.com/sgmap/beta.gouv.fr/wiki/",59
@@ -34,17 +34,17 @@ experts-intrapreneurs,false,"",9
 startup-ludwig,false,"",3
 marketplace,true,"",0
 startup-mdph,false,"https://mdph.beta.gouv.fr",6
-startup-mes_aides,false,"https://mes-aides.gouv.fr",11
-startup-mes_aid-team,false,"",4
+startup-mes_aid-info,false,"https://mes-aides.gouv.fr",11
+startup-mes_aid,false,"",4
 startup-mpal,false,"",9
 mutinerie,true,"",0
 meta-nouveaux,false,"https://github.com/sgmap/beta.gouv.fr/wiki/Bienvenue",33
 startup-openacademie,false,"",7
 experts-opendata,false,"Actualités et discussions en rapport avec l’ouverture des données. L’équipe #datagouv est sur chat.code.gouv2.fr.",14
 openfisca,false,"",3
-startup-pix,false,"",12
+startup-pix-info,false,"",12
 startup-pix-ci,false,"",3
-startup-pix-team,false,"",4
+startup-pix,false,"",4
 startup-plante_etmoi,false,"Tâches en cours : https://github.com/sgmap/plante-et-moi/projects/1",7
 groupe-pole_emploi,false,"",10
 random-politique,false,"",5
@@ -56,8 +56,8 @@ startup-retraites,false,"",5
 experts-security,false,"",8
 service-public-donnee,true,"",12
 taxi-internal,true,"",0
-startup-taxis,false,"https://le.taxi",11
-startup-taxis-team,false,"",2
+startup-taxis-info,false,"https://le.taxi",11
+startup-taxis,false,"",2
 experts-dev,false,"",30
 tes,false,"",14
 startup-tps,false,"",32

--- a/slack-channels.csv
+++ b/slack-channels.csv
@@ -46,7 +46,7 @@ startup-pix-info,false,"",12
 startup-pix-ci,false,"",3
 startup-pix,false,"",4
 startup-plante_etmoi,false,"Tâches en cours : https://github.com/sgmap/plante-et-moi/projects/1",7
-tribu-pole_emploi,false,"",10
+pole_emploi,true,"",10
 bruit-politique,false,"",5
 random,false,"",57
 meta-recrutement,false,"Qui pourrait nous rejoindre ?",18


### PR DESCRIPTION
Objectif : améliorer la découvrabilité et la navigation dans la multitude de canaux qui existent.

## Amélioration de la découvrabilité en préfixant tous les canaux par catégories.

Catégories proposées :

- `startup-` : canaux liés à des produits.
- `api-` : canaux liés à des API.
- `meta-` : canaux d'organisation interne.
- `bureaux-` : canaux liés à des espaces physiques.
- `random-` : canaux de discussion sans but productif.
- `guilde-` : canaux de discussion liés à des pratiques / compétences.
- `tribu-` : canaux de discussion liés à des rattachements administratifs.

## Amélioration de la lisibilité de `general`

Renommage en `meta-annonces` : utilisé uniquement pour les annonces transverses.

## Amélioration de la lisibilité des canaux de startup

Le suffixe `-internals` est supprimé, et l'ancien canal sans suffixe est suffixé par `-info`. Cela correspond plus à la croissance d'une startup, qui commence avec un volume faible puis atteint un volume tel qu'il vaut mieux créer un autre canal.

## Canaux par défaut

Un nouvel entrant serait abonné par défaut à :

- `meta-annonces` (ex-`general`)
- `meta-nouveaux` (ex-`nouveaux`)
- `meta-strategie` (ex-`fil-rouge`)
- `random`

## Nommage

Les préfixes et suffixes sont séparés par des `-`. Les noms de base sont joints par des `_`.