### PR TITLE
rockets-list : génère une liste des messages Slack contentant une 🚀

### DIFF
--- a/rockets-list.rb
+++ b/rockets-list.rb
@@ -1,0 +1,45 @@
+#!/usr/bin/env ruby
+#
+# Affiche la liste formattée des messages Slack contenant `:rocket:`
+# Usage:
+#   SLACK_API_TOKEN=<token> ./rockets-to-text.rb
+
+require 'json'
+require 'net/http'
+require 'uri'
+
+if ENV['SLACK_API_TOKEN'] == nil
+  raise <<~TOKEN
+    La variable d’environnement `SLACK_API_TOKEN` est vide.
+    Générez un token d’API sur 'https://api.slack.com/custom-integrations/legacy-tokens', et relancez le script en précisant le token.
+    (Exemple : `SLACK_API_TOKEN=<token> ./rockets-to-text.rb`)
+  TOKEN
+end
+
+slack_search_url = 'https://slack.com/api/search.messages'
+params = {
+  token: ENV['SLACK_API_TOKEN'],
+  query: ':rocket:',
+  sort: 'date',
+  sort_dir: 'desc',
+  count: 1000
+}
+
+uri = URI.parse(slack_search_url)
+uri.query = URI.encode_www_form(params)
+
+response = Net::HTTP.get(uri)
+payload = JSON.parse(response)
+
+payload.dig('messages', 'matches').each do |message|
+  date   = Time.at(message['ts'].to_i).strftime('%d/%m/%Y')
+  author = message['username']
+  text   = message['text']
+             .gsub(/:rocket:([[:blank:]]*)/, '')
+             .gsub(/<http([^\s]*)>/, 'http\1')
+  puts <<~TEMPLATE
+    #{date} - @#{author}
+    #{text}
+
+  TEMPLATE
+end


### PR DESCRIPTION
Ajoute un script pour générer une liste des messages Slack contentant une `:rocket:` (cf. https://github.com/sgmap/beta.gouv.fr/issues/612)

Cet script peut être utilisé pour générer manuellement un récapitulatif des dernières rockets, à copier-coller dans une newsletter.

Le script nécessite une clef d'API Slack (à créer sur https://api.slack.com/custom-integrations/legacy-tokens)

Exemple :

```
$ SLACK_API_TOKEN=<token> ./rockets-to-text.rb
22/05/2017 - @samuel_faure
réussi a installer le backend sirene-entreprise rails 100% sans accroc depuis le ansible sur VM (le fait que ce soit sur VM a rendu le truc un peu tricky)

19/05/2017 - @julien
Lancement Dimanche par Dijon de leur programme de végétalisation participative : http://jadopteunarbre.dijon.fr/ ( accompagné par Plante Et Moi )

18/05/2017 - @mattisg
Mise à jour de la fiche sur https://api.gouv.fr/api/openfisca.
Au passage, avez-vous bien rajouté une “star” sur les 6 dépôts qui sont mis en avant sur https://github.com/openfisca ?  :smile:

17/05/2017 - @floby
http://particulier-sandbox.api.gouv.fr|particulier-sandbox.api.gouv.fr !
```

@Morendil tu en penses quoi ?